### PR TITLE
Lower Swift tools version from 6.3 to 6.2

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.3
+// swift-tools-version: 6.2
 
 import PackageDescription
 


### PR DESCRIPTION
OSUI project recently bump 6.1 toolchain to 6.2 toolchain. But we are not able to use 6.3 currently.

Lower Compute's package version so that the Linux build of OSUI can build it without fork this project.